### PR TITLE
Add Minishell.h include to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ${LIBFT}:
 	@echo "libft compiled\n"
 
 %.o: %.c
-	@${CC} ${CFLAGS} -I./readline -I./libft -c $< -o $@
+	@${CC} ${CFLAGS} -I./readline -I./libft -I./includes -c $< -o $@
 
 clean:
 	@make clean -C libft

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/minishell.h"
+#include "minishell.h"
 
 t_env	*ft_setenv(char *key, char *value)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/minishell.h"
+#include "minishell.h"
 
 int	main(int ac, char **av, char **env)
 {

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/minishell.h"
+#include "minishell.h"
 
 void	handle_sigquit(void)
 {


### PR DESCRIPTION
By adding the Minishell. h file to the includes it makes it easier to include and makes it easier to move files around without needing to change the path to the file